### PR TITLE
fix: use displayName instead of name when referencing users [DHIS2-9712]

### DIFF
--- a/src/app/AutoCompleteSearchKeyword.component.js
+++ b/src/app/AutoCompleteSearchKeyword.component.js
@@ -166,7 +166,7 @@ const AutoCompleteSearchKeyword = React.createClass({
 
         // Author Search
         restUtil.requestGetHelper(d2Api,
-            `interpretations?paging=false&fields=id,text,user[id,name]&filter=user.name:ilike:${value}`,
+            `interpretations?paging=false&fields=id,text,user[id,displayName~rename(name)]&filter=user.name:ilike:${value}`,
             (result) => {
                 const keywordList = [];
 
@@ -179,7 +179,7 @@ const AutoCompleteSearchKeyword = React.createClass({
 
         // Commentator Search
         restUtil.requestGetHelper(d2Api,
-            `interpretations?paging=false&fields=id,text,comments[user[id,name]]&filter=comments.user.name:ilike:${value}`,
+            `interpretations?paging=false&fields=id,text,comments[user[id,displayName~rename(name)]]&filter=comments.user.name:ilike:${value}`,
             (result) => {
                 const keywordList = [];
 

--- a/src/app/actions/Comment.action.js
+++ b/src/app/actions/Comment.action.js
@@ -7,7 +7,7 @@ const actions = Action.createActionsFromNames(['listComment', 'addComment', 'del
 actions.listComment
     .subscribe(({ data: [model, id], complete }) => {
         getD2().then(d2 => {
-            const url = `interpretations/${id}?fields=comments[id,created,text,user[id,name]]`;
+            const url = `interpretations/${id}?fields=comments[id,created,text,user[id,displayName~rename(name)]]`;
 
             d2.Api.getApi().get(url)
 				.then(result => {

--- a/src/app/actions/Interpretation.action.js
+++ b/src/app/actions/Interpretation.action.js
@@ -10,13 +10,13 @@ actions.listInterpretation
 .subscribe(({ data: [model, searchData, page], complete, error }) => {
     getD2().then(d2 => {
     let url = 'interpretations?fields=id,type,text,created,lastUpdated,userGroupAccesses[*]'
-        + ',externalAccess,publicAccess,likes,likedBy[id,name],user[id,name]'
-        + ',comments[id,created,latestUpdate,text,user[id,name]]'
-        + ',eventReport[id,name,relativePeriods,userGroupAccesses[*],externalAccess,publicAccess,user[id,name],favorites,subscribers,mentions]'
-        + ',eventChart[id,name,relativePeriods,userGroupAccesses[*],externalAccess,publicAccess,user[id,name],favorites,subscribers,mentions]'
-        + ',chart[id,name,relativePeriods,userGroupAccesses[*],externalAccess,publicAccess,user[id,name],favorites,subscribers,mentions]'
-        + ',map[id,name,mapViews[relativePeriods],userGroupAccesses[*],externalAccess,publicAccess,user[id,name],favorites,subscribers,mentions]'
-        + ',reportTable[id,name,relativePeriods,userGroupAccesses[*],externalAccess,publicAccess,user[id,name],favorites,subscribers,mentions]'
+        + ',externalAccess,publicAccess,likes,likedBy[id,name],user[id,displayName~rename(name)]'
+        + ',comments[id,created,latestUpdate,text,user[id,displayName~rename(name)]]'
+        + ',eventReport[id,name,relativePeriods,userGroupAccesses[*],externalAccess,publicAccess,user[id,displayName~rename(name)],favorites,subscribers,mentions]'
+        + ',eventChart[id,name,relativePeriods,userGroupAccesses[*],externalAccess,publicAccess,user[id,displayName~rename(name)],favorites,subscribers,mentions]'
+        + ',chart[id,name,relativePeriods,userGroupAccesses[*],externalAccess,publicAccess,user[id,displayName~rename(name)],favorites,subscribers,mentions]'
+        + ',map[id,name,mapViews[relativePeriods],userGroupAccesses[*],externalAccess,publicAccess,user[id,displayName~rename(name)],favorites,subscribers,mentions]'
+        + ',reportTable[id,name,relativePeriods,userGroupAccesses[*],externalAccess,publicAccess,user[id,displayName~rename(name)],favorites,subscribers,mentions]'
         + searchData;
 
         if (page !== undefined) {


### PR DESCRIPTION
Fixed by requesting `displayName~rename(name)` instead of `name` when referencing embedded user objects.